### PR TITLE
Update the link to doc file

### DIFF
--- a/src/_includes/options.js
+++ b/src/_includes/options.js
@@ -9,7 +9,7 @@ var loadLocalization = function() {
 };
 
 var onHelpLinkClick = function() {
-    let helpUrl = 'https://github.com/muzuiget/user_agent_overrider/wiki';
+    let helpUrl = 'https://github.com/muzuiget/user_agent_overrider/blob/master/docs/en-US/Preference.md';
     let browserWindow = Utils.getMostRecentWindow('navigator:browser');
     if (browserWindow) {
         let gBrowser = browserWindow.gBrowser;


### PR DESCRIPTION
In the current version of User Agent Overrider, the link “How to write this?” is directing https://github.com/muzuiget/user_agent_overrider/wiki , which has already moved to Preference.md, but the extension is not following this change, this fixes that.