### PR TITLE
Add a new site to get user agent

### DIFF
--- a/docs/en-US/Preference.md
+++ b/docs/en-US/Preference.md
@@ -59,3 +59,4 @@ This page will echo what user-agent reach the server, also **maybe not the same*
 
 * http://www.useragentstring.com/
 * http://www.user-agents.org/
+* http://whatsmyuseragent.com/


### PR DESCRIPTION
Add [What's My User Agent](http://whatsmyuseragent.com/) website into the documentation, which can also get the user string, and get more specific informations about the user agent and the client which you are using to visit this site.